### PR TITLE
removing parity from react-native-svg

### DIFF
--- a/react-native-windows-svg.js
+++ b/react-native-windows-svg.js
@@ -121,7 +121,7 @@ var groupFace = {
     }
 }
 
-export const SVG = requireNativeComponent('RCTSVGView', rectFace);
+export const Svg = requireNativeComponent('RCTSVGView', rectFace);
 export const Rect = requireNativeComponent('RCTRectView', rectFace);
 export const Line = requireNativeComponent('RCTLineView', lineFace);
 export const Circle = requireNativeComponent('RCTCircleView', circleFace);


### PR DESCRIPTION
Hi just changed the name of SVG to Svg as this makes cross platform code to work with[ react-native-svg](https://github.com/react-native-community/react-native-svg). 
Please review and merge or let me know the reason for the imparity.